### PR TITLE
Config instead of FakeConvar

### DIFF
--- a/source/InventorySimulator/InventorySimulator.Api.cs
+++ b/source/InventorySimulator/InventorySimulator.Api.cs
@@ -16,7 +16,7 @@ public partial class InventorySimulator
 {
     public string GetApiUrl(string pathname = "")
     {
-        return $"{invsim_protocol.Value}://{invsim_hostname.Value}{pathname}";
+        return $"{Config.Invsim_protocol}://{Config.Invsim_hostname}{pathname}";
     }
 
     public async Task<T?> Fetch<T>(string pathname, bool rethrow = false)
@@ -88,7 +88,7 @@ public partial class InventorySimulator
                 // Try again to fetch data (up to 3 times).
             }
         }
-        
+
         FetchingPlayerInventory.Remove(steamId);
     }
 
@@ -110,12 +110,12 @@ public partial class InventorySimulator
 
     public async void SendStatTrakIncrement(ulong userId, int targetUid)
     {
-        if (invsim_apikey.Value == "")
+        if (Config.Invsim_apikey == "")
             return;
 
         await Send($"/api/increment-item-stattrak", new
         {
-            apiKey = invsim_apikey.Value,
+            apiKey = Config.Invsim_apikey,
             targetUid,
             userId = userId.ToString()
         });

--- a/source/InventorySimulator/InventorySimulator.Commands.cs
+++ b/source/InventorySimulator/InventorySimulator.Commands.cs
@@ -11,30 +11,30 @@ namespace InventorySimulator;
 
 public partial class InventorySimulator
 {
-    [ConsoleCommand("css_ws", "Refreshes player's inventory.")]
-    public void OnWSCommand(CCSPlayerController? player, CommandInfo _)
+  [ConsoleCommand("css_ws", "Refreshes player's inventory.")]
+  public void OnWSCommand(CCSPlayerController? player, CommandInfo _)
+  {
+    player?.PrintToChat(Localizer["invsim.announce", GetApiUrl()]);
+
+    if (!Config.Invsim_ws_enabled || player == null) return;
+    if (PlayerCooldownManager.TryGetValue(player.SteamID, out var timestamp))
     {
-        player?.PrintToChat(Localizer["invsim.announce", GetApiUrl()]);
-
-        if (!invsim_ws_enabled.Value || player == null) return;
-        if (PlayerCooldownManager.TryGetValue(player.SteamID, out var timestamp))
-        {
-            var cooldown = invsim_ws_cooldown.Value;
-            var diff = Now() - timestamp;
-            if (diff < cooldown)
-            {
-                player.PrintToChat(Localizer["invsim.ws_cooldown", cooldown - diff]);
-                return;
-            }
-        }
-
-        if (FetchingPlayerInventory.Contains(player.SteamID))
-        {
-            player.PrintToChat(Localizer["invsim.ws_in_progress"]);
-            return;
-        }
-
-        RefreshPlayerInventory(player, true);
-        player.PrintToChat(Localizer["invsim.ws_new"]);
+      var cooldown = Config.Invsim_ws_cooldown;
+      var diff = Now() - timestamp;
+      if (diff < cooldown)
+      {
+        player.PrintToChat(Localizer["invsim.ws_cooldown", cooldown - diff]);
+        return;
+      }
     }
+
+    if (FetchingPlayerInventory.Contains(player.SteamID))
+    {
+      player.PrintToChat(Localizer["invsim.ws_in_progress"]);
+      return;
+    }
+
+    RefreshPlayerInventory(player, true);
+    player.PrintToChat(Localizer["invsim.ws_new"]);
+  }
 }

--- a/source/InventorySimulator/InventorySimulator.Config.cs
+++ b/source/InventorySimulator/InventorySimulator.Config.cs
@@ -1,0 +1,30 @@
+using CounterStrikeSharp.API.Core;
+
+namespace InventorySimulator;
+
+public partial class InventorySimulator
+{
+    public required InventorySimulatorConfig Config { get; set; }
+
+    public void OnConfigParsed(InventorySimulatorConfig config)
+    {
+        if (config.Version != ConfigVersion) throw new Exception($"You have a wrong config version. Delete it and restart the server to get the right version ({ConfigVersion})!");
+
+        if (config.Invsim_minmodels < 0 || config.Invsim_minmodels > 2)
+            throw new Exception($"Invsim_minmodels must be 0,1 or 2");
+
+        Config = config;
+    }
+
+}
+public class InventorySimulatorConfig : BasePluginConfig
+{
+    public override int Version { get; set; } = 1;
+    public bool Invsim_stattrak_ignore_bots { get; set; } = true;
+    public bool Invsim_ws_enabled { get; set; } = false;
+    public int Invsim_minmodels { get; set; } = 0;
+    public int Invsim_ws_cooldown { get; set; } = 30;
+    public string Invsim_apikey { get; set; } = "";
+    public string Invsim_hostname { get; set; } = "inventory.cstrike.app";
+    public string Invsim_protocol { get; set; } = "https";
+}

--- a/source/InventorySimulator/InventorySimulator.Events.cs
+++ b/source/InventorySimulator/InventorySimulator.Events.cs
@@ -58,7 +58,7 @@ public partial class InventorySimulator
                 IsPlayerHumanAndValid(attacker) &&
                 IsPlayerPawnValid(attacker));
             var isValidVictim = (
-                invsim_stattrak_ignore_bots.Value
+                Config.Invsim_stattrak_ignore_bots
                     ? IsPlayerHumanAndValid(victim)
                     : IsPlayerValid(victim)) &&
                 IsPlayerPawnValid(victim);

--- a/source/InventorySimulator/InventorySimulator.Give.cs
+++ b/source/InventorySimulator/InventorySimulator.Give.cs
@@ -74,7 +74,7 @@ public partial class InventorySimulator
 
     public void GivePlayerAgent(CCSPlayerController player, PlayerInventory inventory)
     {
-        if (invsim_minmodels.Value > 0)
+        if (Config.Invsim_minmodels > 0)
         {
             // For now any value non-zero will force SAS & Phoenix.
             // In the future: 1 - Map agents only, 2 - SAS & Phoenix.

--- a/source/InventorySimulator/InventorySimulator.State.cs
+++ b/source/InventorySimulator/InventorySimulator.State.cs
@@ -13,13 +13,13 @@ namespace InventorySimulator;
 
 public partial class InventorySimulator
 {
-    public readonly FakeConVar<bool> invsim_stattrak_ignore_bots = new("invsim_stattrak_ignore_bots", "Whether to ignore StatTrak increments for bot kills.", true);
+    /* public readonly FakeConVar<bool> invsim_stattrak_ignore_bots = new("invsim_stattrak_ignore_bots", "Whether to ignore StatTrak increments for bot kills.", true);
     public readonly FakeConVar<bool> invsim_ws_enabled = new("invsim_ws_enabled", "Whether players can refresh their inventory using !ws.", false);
     public readonly FakeConVar<int> invsim_minmodels = new("invsim_minmodels", "Allows agents or use specific models for each team.", 0, flags: ConVarFlags.FCVAR_NONE, new RangeValidator<int>(0, 2));
     public readonly FakeConVar<int> invsim_ws_cooldown = new("invsim_ws_cooldown", "Cooldown in seconds between player inventory refreshes.", 30);
     public readonly FakeConVar<string> invsim_apikey = new("invsim_apikey", "Inventory Simulator API's key.", "");
     public readonly FakeConVar<string> invsim_hostname = new("invsim_hostname", "Inventory Simulator API's hostname.", "inventory.cstrike.app");
-    public readonly FakeConVar<string> invsim_protocol = new("invsim_protocol", "Inventory Simulator API's protocol.", "https");
+    public readonly FakeConVar<string> invsim_protocol = new("invsim_protocol", "Inventory Simulator API's protocol.", "https"); */
 
     public readonly HashSet<ulong> FetchingPlayerInventory = [];
     public readonly HashSet<ulong> LoadedPlayerInventory = [];

--- a/source/InventorySimulator/InventorySimulator.cs
+++ b/source/InventorySimulator/InventorySimulator.cs
@@ -10,12 +10,13 @@ using CounterStrikeSharp.API.Modules.Memory;
 namespace InventorySimulator;
 
 [MinimumApiVersion(235)]
-public partial class InventorySimulator : BasePlugin
+public partial class InventorySimulator : BasePlugin, IPluginConfig<InventorySimulatorConfig>
 {
     public override string ModuleAuthor => "Ian Lucas";
     public override string ModuleDescription => "Inventory Simulator (inventory.cstrike.app)";
     public override string ModuleName => "InventorySimulator";
     public override string ModuleVersion => "1.0.0";
+    public static int ConfigVersion => 1;
 
     public override void Load(bool hotReload)
     {


### PR DESCRIPTION
Since you don’t check for FakeConvar updates, I think it’s more useful to use Config instead. It’s easier for server owners to set up settings via Config than to set each convar in the server.cfg file.


btw, nice release...loving this plugin 