### PR TITLE
refactor: ditch hashset states

### DIFF
--- a/source/InventorySimulator/InventorySimulator.Api.cs
+++ b/source/InventorySimulator/InventorySimulator.Api.cs
@@ -66,10 +66,10 @@ public partial class InventorySimulator
         if (!force && existing != null)
             return;
 
-        if (FetchingPlayerInventory.Contains(steamId))
+        if (FetchingPlayerInventory.ContainsKey(steamId))
             return;
 
-        FetchingPlayerInventory.Add(steamId);
+        FetchingPlayerInventory.TryAdd(steamId, true);
 
         for (var attempt = 0; attempt < 3; attempt++)
         {
@@ -93,7 +93,7 @@ public partial class InventorySimulator
             }
         }
 
-        FetchingPlayerInventory.Remove(steamId);
+        FetchingPlayerInventory.Remove(steamId, out var _);
     }
 
     public async void RefreshPlayerInventory(CCSPlayerController player, bool force = false)

--- a/source/InventorySimulator/InventorySimulator.Commands.cs
+++ b/source/InventorySimulator/InventorySimulator.Commands.cs
@@ -30,7 +30,7 @@ public partial class InventorySimulator
             }
         }
 
-        if (FetchingPlayerInventory.Contains(player.SteamID))
+        if (FetchingPlayerInventory.ContainsKey(player.SteamID))
         {
             player.PrintToChat(Localizer["invsim.ws_in_progress"]);
             return;

--- a/source/InventorySimulator/InventorySimulator.Hooks.cs
+++ b/source/InventorySimulator/InventorySimulator.Hooks.cs
@@ -26,7 +26,7 @@ public partial class InventorySimulator
             var player = Utilities.GetPlayerFromUserid((int)userid);
             if (player != null && !player.IsBot)
             {
-                if (!FetchingPlayerInventory.Contains(player.SteamID))
+                if (!FetchingPlayerInventory.ContainsKey(player.SteamID))
                     RefreshPlayerInventory(player);
                 var allowed = PlayerInventoryManager.ContainsKey(player.SteamID);
                 if (state >= 0 && !allowed)

--- a/source/InventorySimulator/InventorySimulator.Player.cs
+++ b/source/InventorySimulator/InventorySimulator.Player.cs
@@ -27,7 +27,7 @@ public partial class InventorySimulator
                 LoadedPlayerInventory.Clear();
                 foreach (var pair in inventories)
                 {
-                    LoadedPlayerInventory.Add(pair.Key);
+                    LoadedPlayerInventory.TryAdd(pair.Key, true);
                     AddPlayerInventory(pair.Key, pair.Value);
                 }
             }
@@ -63,7 +63,7 @@ public partial class InventorySimulator
 
     public void RemovePlayerInventory(ulong steamId)
     {
-        if (!LoadedPlayerInventory.Contains(steamId))
+        if (!LoadedPlayerInventory.ContainsKey(steamId))
         {
             PlayerInventoryManager.Remove(steamId, out _);
             PlayerCooldownManager.Remove(steamId, out _);

--- a/source/InventorySimulator/InventorySimulator.State.cs
+++ b/source/InventorySimulator/InventorySimulator.State.cs
@@ -33,9 +33,8 @@ public partial class InventorySimulator
     public readonly FakeConVar<string> invsim_file = new("invsim_file", "File to load when plugin is loaded.", "inventories.json");
     // csharpier-ignore-end
 
-    public readonly HashSet<ulong> FetchingPlayerInventory = [];
-    public readonly HashSet<ulong> LoadedPlayerInventory = [];
-
+    public readonly ConcurrentDictionary<ulong, bool> FetchingPlayerInventory = [];
+    public readonly ConcurrentDictionary<ulong, bool> LoadedPlayerInventory = [];
     public readonly ConcurrentDictionary<ulong, long> PlayerCooldownManager = [];
     public readonly ConcurrentDictionary<ulong, long> PlayerSprayCooldownManager = [];
     public readonly ConcurrentDictionary<ulong, (CCSPlayerController?, PlayerInventory)> PlayerOnTickInventoryManager = [];


### PR DESCRIPTION
Uses ConcurrentDictionary to avoid possible runtime errors when adding items to HashSet states, alternative refactor that doesn't rely on locks (#42).